### PR TITLE
Remove loading limit

### DIFF
--- a/client/src/views/Gallery/Gallery.jsx
+++ b/client/src/views/Gallery/Gallery.jsx
@@ -101,9 +101,9 @@ const Gallery = () => {
         getGalleryObjects().then((response) => {
             setGalleryObjects(response.data);
             //Convert gallery objects into JSX gallery items
-            // 12 is the max number of gallery items to display on load. Lazy loading should be implemented later
+            //Lazy loading should be implemented later
 
-            const x = Math.min(12, response.data?.length || 0);
+            const x = response.data?.length || 0;
 
             let tempItems = [];
             try {


### PR DESCRIPTION
Remove loading limit so all gallery items will load. Should add lazy loading later which is what the limit was initially intended for.